### PR TITLE
Fix search open new tab

### DIFF
--- a/DPRHTML/dictionary.html
+++ b/DPRHTML/dictionary.html
@@ -7,11 +7,6 @@
   <script>
    $(document).ready(function() {
       DPROpts.dictOptions();
-      $('#dictButton').on('click', function() {
-        DPR_PAL.closeSideBar();
-        $("#mafbc").load("dictionary-results.html");
-      });
-
       DPR_PAL.enablePopover('#dictinInfo', 'focus');
     });
   </script>

--- a/DPRHTML/search.html
+++ b/DPRHTML/search.html
@@ -48,7 +48,6 @@
       DPR_PAL.closeSideBar();
       DPRSend.sendSearch(DPRSend.eventSend(event));
       setSearchParams();
-      $("#mafbc").load("search-results.html");
     }
     $(document).ready(function() {
       setSearchParams();

--- a/digitalpalireader/content/js/dict.js
+++ b/digitalpalireader/content/js/dict.js
@@ -592,7 +592,15 @@ function dppnFullTextSearch (getstring) {
   getstring = toUni(getstring)
   for (i = 1; i < 10; i++) {
     var xmlhttp = new window.XMLHttpRequest()
-    xmlhttp.open('GET', 'etc/XML2/' + i + '.xml', false)
+    if (DPR_PAL.isXUL) {
+      xmlhttp.open('GET', 'etc/XML2/' + i + '.xml', false)
+    } else {
+      xmlhttp.open(
+        'GET',
+        '../digitalpalireader/content/etc/XML2/' + i + '.xml',
+        false
+      )
+    }
     xmlhttp.send(null)
     var xmlDoc = xmlhttp.responseXML.documentElement
 

--- a/digitalpalireader/content/js/dict.js
+++ b/digitalpalireader/content/js/dict.js
@@ -309,7 +309,7 @@ function pedFullTextSearch (getstring) {
     } else {
       xmlhttp.open(
         'GET',
-        '../digitalpalireader/content/etc/XML1/' + i + '/ped.xml',
+        '/digitalpalireader/content/etc/XML1/' + i + '/ped.xml',
         false
       )
     }
@@ -597,7 +597,7 @@ function dppnFullTextSearch (getstring) {
     } else {
       xmlhttp.open(
         'GET',
-        '../digitalpalireader/content/etc/XML2/' + i + '.xml',
+        '/digitalpalireader/content/etc/XML2/' + i + '.xml',
         false
       )
     }
@@ -657,13 +657,15 @@ function dppnFullTextSearch (getstring) {
           .replace(/<c0>/g, '<span style="color:' + DPR_prefs['colped'] + '">')
           .replace(/<xc>/g, '</span>')
 
+        let scrollTopElem = DPR_PAL.isXUL ? "dictc" : "paliTextContent"
+
         finalouta.push(
           ttitle +
             '###<hr class="thick"><a name="dppno' +
             i +
             '/' +
             j +
-            '"><div style="position:relative"><div style="position:absolute;top:0px; left:0px;"><a href="javascript:void(0)" onclick="document.getElementById(\'dictc\').scrollTop = 0;" class="small" style="color:' +
+            '"><div style="position:relative"><div style="position:absolute;top:0px; left:0px;"><a href="javascript:void(0)" onclick="document.getElementById(\''+scrollTopElem+'\').scrollTop = 0;" class="small" style="color:' +
             DPR_prefs['colped'] +
             '">top</a></div><br/>' +
             postpara.replace(/\[/g, '<').replace(/\]/g, '>') +

--- a/digitalpalireader/content/js/web/chrome_sidebar.js
+++ b/digitalpalireader/content/js/web/chrome_sidebar.js
@@ -30,12 +30,8 @@ var DPRChrome = {
   },
   openDPRTab: function (permalink, id, reuse) {
 
-      if (permalink.indexOf('?feature=search') > -1) {
-        var newSearchTab = window.open(permalink, id).focus();
-        newSearchTab.$("#mafbc").load("search-results.html");
-      } else if (permalink.indexOf('?feature=dictionary') > -1) {
-        var newDictTab = window.open(permalink, id).focus();
-        newDictTab.$("#mafbc").load("dictionary-results.html");
+      if (permalink.indexOf('?feature=search') > -1 || permalink.indexOf('?feature=dictionary') > -1) {
+        window.open(permalink, id).focus();
       }
       else {
         window.location.href = permalink;

--- a/digitalpalireader/content/js/web/chrome_sidebar.js
+++ b/digitalpalireader/content/js/web/chrome_sidebar.js
@@ -30,15 +30,16 @@ var DPRChrome = {
   },
   openDPRTab: function (permalink, id, reuse) {
 
-      window.history.pushState("string", id, permalink);
-
       if (permalink.indexOf('?feature=search') > -1) {
-        $("#mafbc").load("search-results.html");
+        var newSearchTab = window.open(permalink, id).focus();
+        newSearchTab.$("#mafbc").load("search-results.html");
       } else if (permalink.indexOf('?feature=dictionary') > -1) {
-        $("#mafbc").load("dictionary-results.html");
+        var newDictTab = window.open(permalink, id).focus();
+        newDictTab.$("#mafbc").load("dictionary-results.html");
       }
       else {
         window.location.href = permalink;
+        window.history.pushState("string", id, permalink);
       }
 
   },


### PR DESCRIPTION
Closes #53
Closes #104

- This should fix both https://github.com/parthopdas/digitalpalireader/issues/53 and https://github.com/parthopdas/digitalpalireader/issues/104.
- Fixes also a new found bug in Dictionary DPPN Full text search.
- Both Search and Dictionary results are opened in a new tab, if starting from navigation tab.
- In a future release, we should keep only one instance of the sidebar throughout several tabs. Different sidebar states for different tabs are confusing.
- In Firefox, depending on browser settings, it might be necessary for the user to confirm once opening of pop-up when using enter key in search field. In my own tests, I had to do this once. See https://javascript.info/popup-windows.